### PR TITLE
fix: add missing fieldset attributes

### DIFF
--- a/cfg/spec_html.go
+++ b/cfg/spec_html.go
@@ -204,14 +204,12 @@ var HTML = &pb.Namespace{
 		},
 
 		{
-
 			Key:         "slot",
 			Description: `The slot global attribute assigns a slot in a shadow DOM shadow tree to an element: An element with a slot attribute is assigned to the slot created by the <slot> element whose name attribute's value matches that slot attribute's value.`,
 			Type:        AttributeTypeString(),
 		},
 
 		{
-
 			Key:         "spellcheck",
 			Description: `The spellcheck global attribute is an enumerated attribute that defines whether the element may be checked for spelling errors. If this attribute is not set, its default value is element-type and browser-defined. This default value may also be inherited, which means that the element content will be checked for spelling errors only if its nearest ancestor has a spellcheck state of true. Security and privacy concerns Using spellchecking can have consequences for users' security and privacy. The specification does not regulate how spellchecking is done and the content of the element may be sent to a third party for spellchecking results (see enhanced spellchecking and "spell-jacking"). You should consider setting spellcheck to false for elements that can contain sensitive information.`,
 			Type: AttributeTypeChoices(
@@ -222,28 +220,24 @@ var HTML = &pb.Namespace{
 		},
 
 		{
-
 			Key:         "style",
 			Description: `The style global attribute is used to add styles to an element, such as color, font, size, and more. Styles are written in CSS.`,
 			Type:        AttributeTypeKVColonSemicolon(),
 		},
 
 		{
-
 			Key:         "tabindex",
 			Description: `The tabindex global attribute indicates if its element can be focused, and if/where it participates in sequential keyboard navigation (usually with the Tab key, hence the name). It accepts an integer as a value, with different results depending on the integer's value: a negative value (usually tabindex="-1") means that the element should be focusable, but should not be reachable via sequential keyboard navigation; a value of 0 (tabindex="0") means that the element should be focusable and reachable via sequential keyboard navigation, but its relative order is defined by the platform convention; a positive value means should be focusable and reachable via sequential keyboard navigation; its relative order is defined by the value of the attribute: the sequential follow the increasing number of the tabindex. If several elements share the same tabindex, their relative order follows their relative position in the document.`,
 			Type:        AttributeTypeInt(),
 		},
 
 		{
-
 			Key:         "title",
 			Description: `The title global attribute contains text representing advisory information related to the element it belongs to. Such information can typically, but not necessarily, be presented to the user as a tooltip. The main use of the title attribute is to label <iframe> elements for assistive technology. The title attribute may also be used to label controls in data tables. The title attribute, when added to <link rel="stylesheet">, creates an alternate stylesheet. When defining an alternative style sheet with <link rel="alternate"> the attribute is required and must be set to a non-empty string. If included on the <abbr> opening tag, the title must be a full expansion of the abbreviation or acronym. Instead of using title, when possible, provide an expansion of the abbreviation or acronym in plain text on first use, using the <abbr> to mark up the abbreviation. This enables all users know what name or term the abbreviation or acronym shortens while providing a hint to user agents on how to announce the content. While title can be used to provide a programmatically associated label for an <input> element, this is not good practice. Use a <label> instead.`,
 			Type:        AttributeTypeString(),
 		},
 
 		{
-
 			Key:         "translate",
 			Description: `The translate global attribute is an enumerated attribute that is used to specify whether an element's attribute values and the values of its Text node children are to be translated when the page is localized, or whether to leave them unchanged.`,
 			Type: AttributeTypeChoices(
@@ -783,6 +777,23 @@ var HTML = &pb.Namespace{
 		{
 			Tag:         "fieldset",
 			Description: "The HTML <fieldset> element is used to group several controls as well as labels (<label>) within a web form.",
+			Attributes: []*pb.Attribute{
+				{
+					Key:         "disabled",
+					Description: "If this Boolean attribute is set, all form controls that are descendants of the <fieldset>, are disabled, meaning they are not editable and won't be submitted along with the <form>.",
+					Type:        AttributeTypeBool(),
+				},
+				{
+					Key:         "form",
+					Description: "This attribute takes the value of the id attribute of a <form> element you want the <fieldset> to be part of, even if it is not inside the form.",
+					Type:        AttributeTypeString(),
+				},
+				{
+					Key:         "name",
+					Description: "The name associated with the group.",
+					Type:        AttributeTypeString(),
+				},
+			},
 		},
 
 		{

--- a/elements/html_fieldset.go
+++ b/elements/html_fieldset.go
@@ -164,6 +164,127 @@ func (e *FIELDSETElement) CustomDataRemove(key string) *FIELDSETElement {
 	return e
 }
 
+// If this Boolean attribute is set, all form controls that are descendants of the
+// <fieldset>, are disabled, meaning they are not editable and won't be submitted
+// along with the <form>.
+func (e *FIELDSETElement) DISABLED() *FIELDSETElement {
+	e.DISABLEDSet(true)
+	return e
+}
+
+func (e *FIELDSETElement) IfDISABLED(condition bool) *FIELDSETElement {
+	if condition {
+		e.DISABLEDSet(true)
+	}
+	return e
+}
+
+// Set the attribute DISABLED to the value b explicitly.
+func (e *FIELDSETElement) DISABLEDSet(b bool) *FIELDSETElement {
+	if e.BoolAttributes == nil {
+		e.BoolAttributes = treemap.New[string, bool]()
+	}
+	e.BoolAttributes.Set("disabled", b)
+	return e
+}
+
+func (e *FIELDSETElement) IfSetDISABLED(condition bool, b bool) *FIELDSETElement {
+	if condition {
+		e.DISABLEDSet(b)
+	}
+	return e
+}
+
+// Remove the attribute DISABLED from the element.
+func (e *FIELDSETElement) DISABLEDRemove(b bool) *FIELDSETElement {
+	if e.BoolAttributes == nil {
+		return e
+	}
+	e.BoolAttributes.Del("disabled")
+	return e
+}
+
+// This attribute takes the value of the id attribute of a <form> element you want
+// the <fieldset> to be part of, even if it is not inside the form.
+func (e *FIELDSETElement) FORM(s string) *FIELDSETElement {
+	if e.StringAttributes == nil {
+		e.StringAttributes = treemap.New[string, string]()
+	}
+	e.StringAttributes.Set("form", s)
+	return e
+}
+
+func (e *FIELDSETElement) FORMF(format string, args ...any) *FIELDSETElement {
+	return e.FORM(fmt.Sprintf(format, args...))
+}
+
+func (e *FIELDSETElement) IfFORM(condition bool, s string) *FIELDSETElement {
+	if condition {
+		e.FORM(s)
+	}
+	return e
+}
+
+func (e *FIELDSETElement) IfFORMF(condition bool, format string, args ...any) *FIELDSETElement {
+	if condition {
+		e.FORM(fmt.Sprintf(format, args...))
+	}
+	return e
+}
+
+// Remove the attribute FORM from the element.
+func (e *FIELDSETElement) FORMRemove(s string) *FIELDSETElement {
+	if e.StringAttributes == nil {
+		return e
+	}
+	e.StringAttributes.Del("form")
+	return e
+}
+
+func (e *FIELDSETElement) FORMRemoveF(format string, args ...any) *FIELDSETElement {
+	return e.FORMRemove(fmt.Sprintf(format, args...))
+}
+
+// The name associated with the group.
+func (e *FIELDSETElement) NAME(s string) *FIELDSETElement {
+	if e.StringAttributes == nil {
+		e.StringAttributes = treemap.New[string, string]()
+	}
+	e.StringAttributes.Set("name", s)
+	return e
+}
+
+func (e *FIELDSETElement) NAMEF(format string, args ...any) *FIELDSETElement {
+	return e.NAME(fmt.Sprintf(format, args...))
+}
+
+func (e *FIELDSETElement) IfNAME(condition bool, s string) *FIELDSETElement {
+	if condition {
+		e.NAME(s)
+	}
+	return e
+}
+
+func (e *FIELDSETElement) IfNAMEF(condition bool, format string, args ...any) *FIELDSETElement {
+	if condition {
+		e.NAME(fmt.Sprintf(format, args...))
+	}
+	return e
+}
+
+// Remove the attribute NAME from the element.
+func (e *FIELDSETElement) NAMERemove(s string) *FIELDSETElement {
+	if e.StringAttributes == nil {
+		return e
+	}
+	e.StringAttributes.Del("name")
+	return e
+}
+
+func (e *FIELDSETElement) NAMERemoveF(format string, args ...any) *FIELDSETElement {
+	return e.NAMERemove(fmt.Sprintf(format, args...))
+}
+
 // The accesskey global attribute provides a hint for generating a keyboard
 // shortcut for the current element
 // The attribute value must consist of a single printable character (which

--- a/tests/attributes_test.go
+++ b/tests/attributes_test.go
@@ -1,0 +1,41 @@
+package tests
+
+import (
+	"testing"
+
+	. "github.com/delaneyj/gostar/elements"
+	"github.com/stretchr/testify/assert"
+	"github.com/valyala/bytebufferpool"
+)
+
+func TestAttributes(t *testing.T) {
+	type ExpectedResult struct {
+		Expected string
+		Actual   ElementRenderer
+	}
+
+	expectedResults := []ExpectedResult{
+		{
+			Expected: `<fieldset disabled></fieldset>`,
+			Actual:   FIELDSET().DISABLED(),
+		},
+		{
+			Expected: `<fieldset form="form"></fieldset>`,
+			Actual:   FIELDSET().FORM("form"),
+		},
+		{
+			Expected: `<fieldset name="fieldset"></fieldset>`,
+			Actual:   FIELDSET().NAME("fieldset"),
+		},
+	}
+
+	for _, expectedResult := range expectedResults {
+		buf := bytebufferpool.Get()
+		e := expectedResult.Expected
+		err := expectedResult.Actual.Render(buf)
+		assert.NoError(t, err)
+		a := buf.String()
+		assert.Equal(t, e, a)
+		bytebufferpool.Put(buf)
+	}
+}


### PR DESCRIPTION
In `cfg/spec_html.go`, the `fieldset` element is missing the attributes `disabled`, `form` and `name`.

Source: https://html.spec.whatwg.org/multipage/form-elements.html#the-fieldset-element

I aslo added some tests. 